### PR TITLE
[Refactor] 이미지 최적화를 위한 파일 크기 조정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ dependencies {
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.477'
     implementation 'commons-fileupload:commons-fileupload:1.4'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation group: 'net.coobird', name: 'thumbnailator', version: '0.4.8'
 
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 

--- a/src/main/java/com/example/vblogserver/domain/user/service/ImageService.java
+++ b/src/main/java/com/example/vblogserver/domain/user/service/ImageService.java
@@ -1,20 +1,22 @@
 package com.example.vblogserver.domain.user.service;
 
-import java.io.IOException;
-import java.net.URI;
-import java.util.UUID;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.example.vblogserver.domain.user.entity.User;
 import com.example.vblogserver.domain.user.repository.UserRepository;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.coobird.thumbnailator.Thumbnails;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -23,24 +25,39 @@ public class ImageService {
 	private static final String USER_IMAGE_FOLDER = "userImage/";
 	private final AmazonS3 s3Client;
 	private final UserRepository userRepository;
+
 	@Value("${cloud.aws.s3.bucket}")
 	private String bucket;
 
 	public String uploadFile(MultipartFile multipartFile) throws IOException {
+
+		byte[] optimizedImage = optimizeImage(multipartFile);
+
 		String fileName = UUID.randomUUID().toString() + "_" + multipartFile.getOriginalFilename();
 
 		ObjectMetadata objectMetadata = new ObjectMetadata();
 		objectMetadata.setContentType(multipartFile.getContentType());
-		objectMetadata.setContentLength(multipartFile.getSize());
+		objectMetadata.setContentLength(optimizedImage.length);
+
+		InputStream optimizedImageInputStream = new ByteArrayInputStream(optimizedImage);
 
 		s3Client.putObject(
-			bucket,
-			USER_IMAGE_FOLDER + fileName,
-			multipartFile.getInputStream(),
-			objectMetadata
+				bucket,
+				USER_IMAGE_FOLDER + fileName,
+				optimizedImageInputStream,
+				objectMetadata
 		);
 
 		return s3Client.getUrl(bucket, USER_IMAGE_FOLDER + fileName).toString();
+	}
+
+	private byte[] optimizeImage(MultipartFile multipartFile) throws IOException {
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+		Thumbnails.of(multipartFile.getInputStream())
+				.size(800, 800)
+				.outputQuality(0.75)
+				.toOutputStream(outputStream);
+		return outputStream.toByteArray();
 	}
 
 	public String updateProfileImage(User user, MultipartFile file) throws IOException {
@@ -59,7 +76,7 @@ public class ImageService {
 	public void deleteProfileImage(User user) {
 		if (user.getImageUrl() != null) {
 			URI url = URI.create(user.getImageUrl());
-			String key = url.getPath().substring(1); // URL에서 버킷 이름 다음부터가 key 입니다.
+			String key = url.getPath().substring(1); // URL에서 버킷 이름 다음부터가 key
 
 			s3Client.deleteObject(bucket, key);
 			user.setImageUrl(null);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,9 @@ server:
     encoding:
       force: true
       charset: UTF-8
+    multipart:
+      maxFileSize: 10MB # 파일 하나의 최대 크기
+      maxRequestSize: 30MB  # 한 번에 최대 업로드 가능 용량
 
 spring:
   mvc:


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 반영 브랜치 및 이슈
- feat/login -> dev
- 관련 이슈를 입력해주세요.
closed #7 
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 💡 개요
- 기존 서버 저장 공간 부담과 로딩 속도 개선을 위해 이미지를 최적화하여 업로드하면, 서버 저장 공간과 대역폭을 절약할 수 있으며, 사용자에게 더 빠른 로딩 속도를 제공하기 위해 최적화 진행.

### 🔑 주요 변경사항
1. Thumbnails 라이브러리 추가: 
- 이미지 최적화를 위해 이미지 리사이즈 및 압축 할 수 있는 Thumbnails 라이브러리 사용

2. 이미지 최적화 optimizeImage 메서드 추가:
- MultipartFile을 입력으로 받아 최적화된 이미지를 byte[] 형식으로 반환
- Thumbnails.of(multipartFile.getInputStream())를 사용하여 이미지를 로드
- .size(800, 800)로 이미지 크기를 조정하며, .outputQuality(0.75)로 이미지 품질 설정
- 최적화된 이미지를 ByteArrayOutputStream에 저장하고, 이를 byte[]로 반환

3. 업로드 uploadFile 메서드 수정:
- 원본 이미지를 바로 업로드하는 대신, optimizeImage 메서드를 호출하여 최적화된 이미지를 업로드
- ObjectMetadata의 setContentLength를 최적화된 이미지의 크기로 설정

### 🏞 스크린샷
스크린샷을 첨부해주세요.

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
